### PR TITLE
Fix typos from `expired_at` to `expires_as`

### DIFF
--- a/src/xerotrust/exceptions.py
+++ b/src/xerotrust/exceptions.py
@@ -1,4 +1,4 @@
 class XeroAPIException(ValueError):
     """
-    An error occurred when interacting the Xero API
+    An error occurred when interacting with the Xero API
     """

--- a/src/xerotrust/main.py
+++ b/src/xerotrust/main.py
@@ -54,7 +54,7 @@ def login(auth_path: Path, client_id: str) -> None:
 
     now = time.time()
     credentials = authenticate(client_id)
-    if 'expires_in' in credentials.token and 'expired_at' not in credentials.token:
+    if 'expires_in' in credentials.token and 'expires_at' not in credentials.token:
         credentials.token['expires_at'] = now + credentials.token['expires_in']
 
     # Display tenants

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -138,7 +138,7 @@ class TestLogin:
     def test_login_with_expires_in(
         self, mock_authenticate: Mock, tmp_path: Path, pook: Any
     ) -> None:
-        """Test the login command calculates expired_at from expires_in."""
+        """Test the login command calculates expires_at from expires_in."""
         auth_path = tmp_path / '.xerotrust.json'
         add_tenants_response(pook)
 
@@ -161,6 +161,26 @@ class TestLogin:
                 },
             },
             actual=json.loads(auth_path.read_text()),
+        )
+
+    def test_login_preserves_expires_at(
+        self, mock_authenticate: Mock, tmp_path: Path, pook: Any
+    ) -> None:
+        expires_at = 1234.0
+        auth_path = tmp_path / '.xerotrust.json'
+        add_tenants_response(pook)
+
+        mock_authenticate.return_value.token = {
+            'access_token': 'test_token',
+            'expires_in': 3600,
+            'expires_at': expires_at,
+        }
+
+        run_cli(auth_path, 'login', '--client-id', 'ID')
+
+        compare(
+            json.loads(auth_path.read_text())['token']['expires_at'],
+            expected=expires_at,
         )
 
 


### PR DESCRIPTION
## Summary
- verify login token keeps pre-set expires_at
- fix expires_at check during login
- correct login test docstring

## Testing
- `uv run -m pytest tests/test_main.py::TestLogin::test_login_preserves_expires_at -v`
- `uv run -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68405eb95b0c83219827efbf4f4e25fc