### PR TITLE
Refactor flatten to be a top level command

### DIFF
--- a/src/xerotrust/export.py
+++ b/src/xerotrust/export.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from enum import StrEnum
 from pathlib import Path
 from time import sleep
-from typing import Callable, Any, IO, Self, TypeAlias, Iterable, Iterator, ClassVar
+from typing import Callable, Any, IO, Self, TypeAlias, Iterable, ClassVar
 
 from xero.exceptions import XeroRateLimitExceeded
 
@@ -159,37 +159,3 @@ EXPORTS = {
     'Contacts': Export("contacts.jsonl"),
     'Journals': JournalsExport(),
 }
-
-ALL_JOURNAL_KEYS = [
-    'JournalID',
-    'JournalDate',
-    'JournalNumber',
-    'CreatedDateUTC',
-    'JournalLineID',
-    'AccountID',
-    'AccountCode',
-    'AccountType',
-    'AccountName',
-    'Description',
-    'NetAmount',
-    'GrossAmount',
-    'TaxAmount',
-    'TaxType',
-    'TaxName',
-    'TrackingCategories',
-    'Reference',
-    'SourceType',
-    'SourceID',
-]
-
-
-def flatten(rows: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
-    for journal in rows:
-        journal_lines = journal.pop('JournalLines', [])
-        for journal_line in journal_lines:
-            full_journal_row = journal.copy()
-            for key, value in journal_line.items():
-                if isinstance(value, (dict, list)):
-                    value = json.dumps(value)
-                full_journal_row[key] = value
-            yield full_journal_row

--- a/src/xerotrust/flatten.py
+++ b/src/xerotrust/flatten.py
@@ -1,0 +1,36 @@
+import json
+from typing import Iterator, Any
+
+ALL_JOURNAL_KEYS = [
+    'JournalID',
+    'JournalDate',
+    'JournalNumber',
+    'CreatedDateUTC',
+    'JournalLineID',
+    'AccountID',
+    'AccountCode',
+    'AccountType',
+    'AccountName',
+    'Description',
+    'NetAmount',
+    'GrossAmount',
+    'TaxAmount',
+    'TaxType',
+    'TaxName',
+    'TrackingCategories',
+    'Reference',
+    'SourceType',
+    'SourceID',
+]
+
+
+def flatten(rows: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    for journal in rows:
+        journal_lines = journal.pop('JournalLines', [])
+        for journal_line in journal_lines:
+            full_journal_row = journal.copy()
+            for key, value in journal_line.items():
+                if isinstance(value, (dict, list)):
+                    value = json.dumps(value)
+                full_journal_row[key] = value
+            yield full_journal_row

--- a/src/xerotrust/main.py
+++ b/src/xerotrust/main.py
@@ -12,7 +12,8 @@ from xero import Xero
 
 from .authentication import authenticate, credentials_from_file
 from .check import check_journals, show_summary
-from .export import EXPORTS, FileManager, Split, ALL_JOURNAL_KEYS, flatten, LatestData
+from .export import EXPORTS, FileManager, Split, LatestData
+from .flatten import flatten, ALL_JOURNAL_KEYS
 from .transform import TRANSFORMERS, show
 
 
@@ -279,7 +280,7 @@ def check_command(paths: tuple[Path, ...]) -> None:
     )
 
 
-@journals.command('flatten')
+@cli.command('flatten')
 @click.argument(
     'paths',
     type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
@@ -296,10 +297,10 @@ def check_command(paths: tuple[Path, ...]) -> None:
 )
 def flatten_command(paths: tuple[Path, ...], output_file: click.utils.LazyFile) -> None:
     """
-    Flatten journal entries from JSONL files into CSV format.
+    Flatten journal entries, augmenting them with transaction data if requested, into CSV format.
 
-    Each JournalLine within a Journal becomes a row in the CSV,
-    combined with data from its parent Journal.
+    Each JournalLine within a Journal becomes a row in the CSV, combined with data from its parent
+    Journal and any supplied transactions.
     """
     # The type hint for output_file from click.File('w') is IO[str],
     # but click.utils.LazyFile is what's actually passed at runtime before it's opened.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,7 +15,7 @@ from xero.auth import OAuth2PKCECredentials
 from xerotrust import export
 from xerotrust import main
 from xerotrust.authentication import authenticate, SCOPES, credentials_from_file
-from xerotrust.export import ALL_JOURNAL_KEYS
+from xerotrust.flatten import ALL_JOURNAL_KEYS
 from xerotrust.main import cli
 from xerotrust.transform import show
 from .helpers import FileChecker
@@ -1375,7 +1375,7 @@ class TestJournalsCheck:
         )
 
 
-class TestJournalsFlatten:
+class TestFlatten:
     def write_journal_file(self, path: Path, journals: list[dict[str, Any]]) -> None:
         """Helper to write a JSON Lines file."""
         path.write_text('\n'.join(json.dumps(j) for j in journals) + '\n')
@@ -1409,7 +1409,7 @@ class TestJournalsFlatten:
         ]
         self.write_journal_file(journal_file, journals_data)
 
-        result = run_cli(tmp_path, 'journals', 'flatten', str(journal_file))
+        result = run_cli(tmp_path, 'flatten', str(journal_file))
 
         # We don't use check_output here so we can see what the raw csv looks like,
         header = ','.join(ALL_JOURNAL_KEYS)
@@ -1441,7 +1441,7 @@ class TestJournalsFlatten:
         self.write_journal_file(file1, journals_data1)
         self.write_journal_file(file2, journals_data2)
 
-        result = run_cli(tmp_path, 'journals', 'flatten', str(file1), str(file2))
+        result = run_cli(tmp_path, 'flatten', str(file1), str(file2))
 
         expected_rows = [
             {'JournalID': 'j1', 'JournalNumber': 1, 'JournalLineID': 'jl1a'},
@@ -1453,7 +1453,7 @@ class TestJournalsFlatten:
         empty_file = tmp_path / "empty.jsonl"
         empty_file.touch()
 
-        result = run_cli(tmp_path, 'journals', 'flatten', str(empty_file))
+        result = run_cli(tmp_path, 'flatten', str(empty_file))
 
         self.check_output(result.output, expected=[])
 
@@ -1465,7 +1465,7 @@ class TestJournalsFlatten:
         ]
         self.write_journal_file(journal_file, journals_data)
 
-        result = run_cli(tmp_path, 'journals', 'flatten', str(journal_file))
+        result = run_cli(tmp_path, 'flatten', str(journal_file))
 
         self.check_output(result.output, expected=[])
 
@@ -1491,7 +1491,7 @@ class TestJournalsFlatten:
         ]
         self.write_journal_file(journal_file, journals_data)
 
-        result = run_cli(tmp_path, 'journals', 'flatten', str(journal_file))
+        result = run_cli(tmp_path, 'flatten', str(journal_file))
 
         expected_rows = [
             {
@@ -1523,7 +1523,6 @@ class TestJournalsFlatten:
 
         run_cli(
             tmp_path,
-            'journals',
             'flatten',
             str(journal_file),
             '--output',
@@ -1555,7 +1554,7 @@ class TestJournalsFlatten:
         ]
         self.write_journal_file(journal_file, journals_data)
 
-        result = run_cli(tmp_path, 'journals', 'flatten', str(journal_file))
+        result = run_cli(tmp_path, 'flatten', str(journal_file))
 
         expected_rows = [
             {


### PR DESCRIPTION
## Summary
- Moves the `flatten` command from being a subcommand of `journals` to a top-level CLI command
- Extracts flatten functionality and journal keys to a separate `flatten.py` module
- Updates command help text to prepare for future enhancement with bank transaction data

## Test plan
- [x] All existing flatten tests pass
- [x] Command can be run as `xerotrust flatten` instead of `xerotrust journals flatten`
- [x] Functionality remains unchanged for current use cases

🤖 Generated with [Claude Code](https://claude.ai/code)