### PR TITLE
Restructure check command

### DIFF
--- a/src/xerotrust/check.py
+++ b/src/xerotrust/check.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from pathlib import Path
 from typing import Iterable, Any, Sequence, Iterator
 
@@ -69,6 +70,7 @@ def show_summary(journals: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]
     fields = 'JournalNumber', 'JournalDate', 'CreatedDateUTC'
     count = 0
     data = {field: {"min": None, "max": None} for field in fields}
+    source_type_counts: defaultdict[str, int] = defaultdict(int)
 
     for count, journal in enumerate(journals, start=1):
         for field in fields:
@@ -82,6 +84,10 @@ def show_summary(journals: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]
                     data[field]["min"] = value
                 if current_max is None or value > current_max:
                     data[field]["max"] = value
+
+        # Count SourceType occurrences
+        source_type_counts[journal.get("SourceType", "<none>")] += 1
+
         yield journal
 
     padding = max(len(field) for field in fields)
@@ -90,6 +96,12 @@ def show_summary(journals: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]
         min_value = data[field]["min"]
         max_value = data[field]["max"]
         print(f"{field:>{padding}}: {min_value} -> {max_value}")
+
+    # Print SourceType summary
+    print()
+    print("SourceType summary:")
+    for source_type, count in sorted(source_type_counts.items()):
+        print(f"  {source_type}: {count}")
 
 
 CHECKERS = {

--- a/src/xerotrust/main.py
+++ b/src/xerotrust/main.py
@@ -270,7 +270,7 @@ def check(endpoint: str, paths: tuple[Path, ...]) -> None:
     if endpoint_lower not in CHECKERS:
         raise click.ClickException(f'Unsupported endpoint: {endpoint}')
 
-    stream = jsonl_stream(paths)
+    stream: Iterable[dict[str, Any]] = jsonl_stream(paths)
     steps = CHECKERS[endpoint_lower]
     for step in steps:
         stream = step(stream)

--- a/tests/snapshots/main_check__TestCheck__check_empty_file__0.txt
+++ b/tests/snapshots/main_check__TestCheck__check_empty_file__0.txt
@@ -1,0 +1,6 @@
+       entries: 0
+ JournalNumber: None -> None
+   JournalDate: None -> None
+CreatedDateUTC: None -> None
+
+SourceType summary:

--- a/tests/snapshots/main_check__TestCheck__check_single_entry__0.txt
+++ b/tests/snapshots/main_check__TestCheck__check_single_entry__0.txt
@@ -1,0 +1,7 @@
+       entries: 1
+ JournalNumber: 1 -> 1
+   JournalDate: 2025-01-15T10:00:00 -> 2025-01-15T10:00:00
+CreatedDateUTC: 2025-01-15T10:00:00Z -> 2025-01-15T10:00:00Z
+
+SourceType summary:
+  MANUAL: 1

--- a/tests/snapshots/main_check__TestCheck__check_success_multiple_files__0.txt
+++ b/tests/snapshots/main_check__TestCheck__check_success_multiple_files__0.txt
@@ -1,0 +1,8 @@
+       entries: 3
+ JournalNumber: 1 -> 3
+   JournalDate: 2025-01-15T10:00:00 -> 2025-01-17T10:00:00
+CreatedDateUTC: 2025-01-15T10:00:00Z -> 2025-01-17T10:00:00Z
+
+SourceType summary:
+  CASHPAID: 1
+  TRANSFER: 2

--- a/tests/snapshots/main_check__TestCheck__check_success_single_file__0.txt
+++ b/tests/snapshots/main_check__TestCheck__check_success_single_file__0.txt
@@ -1,0 +1,9 @@
+       entries: 4
+ JournalNumber: 1 -> 4
+   JournalDate: 2025-01-15T10:00:00 -> 2025-01-18T13:00:00
+CreatedDateUTC: 2025-01-15T10:00:00Z -> 2025-01-18T13:00:00Z
+
+SourceType summary:
+  <none>: 1
+  CASHPAID: 1
+  INVOICE: 2


### PR DESCRIPTION
## Summary
- move `journals check` to a new `check` command
- support an endpoint argument when checking
- rename `test_main_journals.py` to `test_main_check.py`

## Testing
- `uv run -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684708a625688321acb1359ccddb4de0