### PR TITLE
Add endpoint argument to flatten command

### DIFF
--- a/src/xerotrust/flatten.py
+++ b/src/xerotrust/flatten.py
@@ -24,7 +24,7 @@ ALL_JOURNAL_KEYS = [
 ]
 
 
-def flatten(rows: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
+def flatten_journals(rows: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
     for journal in rows:
         journal_lines = journal.pop('JournalLines', [])
         for journal_line in journal_lines:
@@ -34,3 +34,8 @@ def flatten(rows: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
                     value = json.dumps(value)
                 full_journal_row[key] = value
             yield full_journal_row
+
+
+FLATTENERS = {
+    'Journals': flatten_journals,
+}

--- a/tests/test_main_flatten.py
+++ b/tests/test_main_flatten.py
@@ -43,7 +43,7 @@ class TestFlatten:
         ]
         self.write_journal_file(journal_file, journals_data)
 
-        result = run_cli(tmp_path, 'flatten', str(journal_file))
+        result = run_cli(tmp_path, 'flatten', 'journals', str(journal_file))
 
         # We don't use check_output here so we can see what the raw csv looks like,
         header = ','.join(ALL_JOURNAL_KEYS)
@@ -75,7 +75,7 @@ class TestFlatten:
         self.write_journal_file(file1, journals_data1)
         self.write_journal_file(file2, journals_data2)
 
-        result = run_cli(tmp_path, 'flatten', str(file1), str(file2))
+        result = run_cli(tmp_path, 'flatten', 'journals', str(file1), str(file2))
 
         expected_rows = [
             {'JournalID': 'j1', 'JournalNumber': 1, 'JournalLineID': 'jl1a'},
@@ -87,7 +87,7 @@ class TestFlatten:
         empty_file = tmp_path / "empty.jsonl"
         empty_file.touch()
 
-        result = run_cli(tmp_path, 'flatten', str(empty_file))
+        result = run_cli(tmp_path, 'flatten', 'journals', str(empty_file))
 
         self.check_output(result.output, expected=[])
 
@@ -99,7 +99,7 @@ class TestFlatten:
         ]
         self.write_journal_file(journal_file, journals_data)
 
-        result = run_cli(tmp_path, 'flatten', str(journal_file))
+        result = run_cli(tmp_path, 'flatten', 'journals', str(journal_file))
 
         self.check_output(result.output, expected=[])
 
@@ -125,7 +125,7 @@ class TestFlatten:
         ]
         self.write_journal_file(journal_file, journals_data)
 
-        result = run_cli(tmp_path, 'flatten', str(journal_file))
+        result = run_cli(tmp_path, 'flatten', 'journals', str(journal_file))
 
         expected_rows = [
             {
@@ -158,6 +158,7 @@ class TestFlatten:
         run_cli(
             tmp_path,
             'flatten',
+            'journals',
             str(journal_file),
             '--output',
             str(output_csv_file),
@@ -188,7 +189,7 @@ class TestFlatten:
         ]
         self.write_journal_file(journal_file, journals_data)
 
-        result = run_cli(tmp_path, 'flatten', str(journal_file))
+        result = run_cli(tmp_path, 'flatten', 'journals', str(journal_file))
 
         expected_rows = [
             {


### PR DESCRIPTION
## Summary
- support endpoints with the `xerotrust flatten` command
- update tests for new CLI usage

## Testing
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565607874c8321982d434166d9ef97