### PR TITLE
Make KeyValueType compatible with click 8.4's generic ParamType

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
-    "click>=8.2",
+    "click>=8.4",
     "enlighten>=1.14.1",
     "fastapi>=0.115.12",
     "hypercorn>=0.17.3",

--- a/src/xerotrust/main.py
+++ b/src/xerotrust/main.py
@@ -288,7 +288,7 @@ def check(endpoint: str, paths: tuple[Path, ...]) -> None:
     deque(stream, maxlen=0)
 
 
-class KeyValueType(click.ParamType):
+class KeyValueType(click.ParamType[list[str]]):
     name = 'key=value'
 
     def convert(


### PR DESCRIPTION
## Summary
- click 8.4.0 made `ParamType` generic and mypy now requires a type argument, breaking CI type checking.
- Parameterize `KeyValueType` as `click.ParamType[list[str]]` to match its `convert` return type.

## Test plan
- [x] uv run mypy src tests
- [x] uv run -m pytest